### PR TITLE
Guard against empty text TemporalAccessorTypeHandler

### DIFF
--- a/src/org/beanio/types/TemporalAccessorTypeHandler.java
+++ b/src/org/beanio/types/TemporalAccessorTypeHandler.java
@@ -45,6 +45,10 @@ public class TemporalAccessorTypeHandler implements ConfigurableTypeHandler {
 
     @Override
     public TemporalAccessor parse(String text) throws TypeConversionException {
+        if (text == null || "".equals(text)) {
+            return null;
+        }
+        
         try {
             TemporalAccessor temporalAccessor = formatter.parse(text);
 

--- a/test/org/beanio/types/TemporalAccessorTypeHandlerTest.java
+++ b/test/org/beanio/types/TemporalAccessorTypeHandlerTest.java
@@ -125,6 +125,18 @@ public class TemporalAccessorTypeHandlerTest {
     }
 
     @Test
+    public void testParseEmptyString() throws TypeConversionException {
+        // Given
+        TypeHandler typeHandler = typeHandlerFactory.getTypeHandlerFor(LocalDateTime.class);
+
+        // When
+        final Object result = typeHandler.parse("");
+
+        // Then
+        assertNull(result);
+    }
+
+    @Test
     public void testNewInstanceWithNullPatternReturnsSameInstance() {
         // Given
         TypeHandler typeHandler = typeHandlerFactory.getTypeHandlerFor(LocalDateTime.class);


### PR DESCRIPTION
Implements similar logic as in https://github.com/willsoto/beanio/blob/c4e032b8e163c232cfc5f018ad961d4343022cc7/src/org/beanio/types/NumberTypeHandler.java#L50-L52 to return `null` in case the value to be parsed is `null`